### PR TITLE
Pre-fill search bar with query config

### DIFF
--- a/UnsplashPhotoPicker.podspec
+++ b/UnsplashPhotoPicker.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |spec|
   spec.name             = 'UnsplashPhotoPicker'
-  spec.version          = '1.1.1'
+  spec.version          = '1.1.2'
   spec.license          = { :type => 'MIT' }
-  spec.homepage         = 'https://github.com/unsplash/unsplash-photopicker-ios'
+  spec.homepage         = 'https://github.com/mikkoasis/unsplash-photopicker-ios'
   spec.authors          = { 'Unsplash' => 'apps@unsplash.com' }
   spec.summary          = 'A photo picker to search for and use photos from Unsplash.'
-  spec.source           = { :git => 'https://github.com/unsplash/unsplash-photopicker-ios.git', :tag => '1.1.1' }
+  spec.source           = { :git => 'https://github.com/mikkoasis/unsplash-photopicker-ios.git', :tag => '1.1.2' }
   spec.source_files     = 'UnsplashPhotoPicker/UnsplashPhotoPicker/**/*.{h,m,swift,xib,strings,stringsdict}'
   spec.framework        = 'Foundation', 'UIKit'
   spec.platform         = :ios, '11.0'

--- a/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashPhotoPickerViewController.swift
+++ b/UnsplashPhotoPicker/UnsplashPhotoPicker/Classes/Controllers/UnsplashPhotoPickerViewController.swift
@@ -171,8 +171,8 @@ class UnsplashPhotoPickerViewController: UIViewController {
 
     private func setupSearchController() {
         let trimmedQuery = Configuration.shared.query?.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let query = trimmedQuery, query.isEmpty == false { return }
 
+        searchController.searchBar.text = trimmedQuery
         navigationItem.searchController = searchController
         navigationItem.hidesSearchBarWhenScrolling = false
         definesPresentationContext = true


### PR DESCRIPTION
Do not hide the search bar when a query is supplied from the configuration